### PR TITLE
Fix buiding issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "jest-pnp-resolver": "1.0.2",
     "jest-resolve": "23.6.0",
     "mini-css-extract-plugin": "0.4.3",
+    "node-fetch": "^2.6.0",
     "node-sass": "^4.13.1",
     "oembed-providers": "^1.0.20170414",
     "optimize-css-assets-webpack-plugin": "5.0.1",

--- a/src/core/media-upload.js
+++ b/src/core/media-upload.js
@@ -1,5 +1,5 @@
 
-import { Component, Fragment } from 'react';
+import React, { Component, Fragment } from 'react';
 import './media-library.scss';
 
 const { wp, lodash } = window;

--- a/src/globals/embeds.js
+++ b/src/globals/embeds.js
@@ -1,3 +1,4 @@
+import { fetch } from 'node-fetch';
 import providers from 'oembed-providers';
 
 export async function getEmbed (url) {


### PR DESCRIPTION
Fix errors output when running start script.

1. React not imported in media-upload.js
2. 'fetch' not defined in src/globals/embeds.js, adding 'node-fetch' package to solve it as status [here](https://github.com/aws-amplify/amplify-js/issues/403#issuecomment-370340635).